### PR TITLE
Use interface in result

### DIFF
--- a/src/Content/Result.php
+++ b/src/Content/Result.php
@@ -19,7 +19,7 @@ abstract class Result implements ResultInterface
     private $request;
 
     /**
-     * @var ResultData
+     * @var ResultDataInterface
      */
     private $resultData;
 
@@ -28,14 +28,14 @@ abstract class Result implements ResultInterface
         $this->request = $request;
     }
 
-    public function setResultData(ResultData $resultData): ResultInterface
+    public function setResultData(ResultDataInterface $resultData): ResultInterface
     {
         $this->resultData = $resultData;
 
         return $this;
     }
 
-    public function getResultData(): ?ResultData
+    public function getResultData(): ?ResultDataInterface
     {
         return $this->resultData;
     }

--- a/src/Content/ResultInterface.php
+++ b/src/Content/ResultInterface.php
@@ -13,9 +13,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 interface ResultInterface
 {
-    public function setResultData(ResultData $resultData): self;
+    public function setResultData(ResultDataInterface $resultData): self;
 
-    public function getResultData(): ?ResultData;
+    public function getResultData(): ?ResultDataInterface;
 
     public function getResponse(): Response;
 }


### PR DESCRIPTION
Replacing types in properties with php doc notation, because typed properties are not available in PHP 7.3.