### PR TITLE
Allow the setting of content type priority

### DIFF
--- a/src/Negotiation/FormatNegotiator.php
+++ b/src/Negotiation/FormatNegotiator.php
@@ -16,6 +16,15 @@ use Symfony\Component\HttpFoundation\Request;
 class FormatNegotiator implements NegotiatorInterface
 {
     /**
+     * @var array<string>
+     */
+    private $priorities = [
+        'text/html',
+        'application/json',
+        'application/xml',
+    ];
+
+    /**
      * @var Negotiator
      */
     private $negotiator;
@@ -30,16 +39,31 @@ class FormatNegotiator implements NegotiatorInterface
         $format    = $request->getRequestFormat();
         $mediaType = $this->negotiator->getBest(
             $request->headers->get('accept'),
-            [
-                'text/html',
-                'application/json',
-                'application/xml',
-            ]
+            $this->priorities
         );
+
         if ($mediaType instanceof Accept) {
             $format = $mediaType->getSubPart();
         }
 
         return $format ?? 'html';
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getPriorities(): array
+    {
+        return $this->priorities;
+    }
+
+    /**
+     * @param array<string> $priorities
+     */
+    public function setPriorities(array $priorities): self
+    {
+        $this->priorities = $priorities;
+
+        return $this;
     }
 }


### PR DESCRIPTION
The negotiation priorities could be different for different cases.
If a user agent sends a request with the following header:
```
Accept: application/json, text/plain, */*
```
The response will be HTML, because `*/*` matches `text/html` which is top
priority by default in the format negotiator.

The user agent expects a json response over a html
response though. Maybe the negotiation in general should change, but
being able to set the priority helps to circumvent the issue.